### PR TITLE
Use short id (8 chars) when deleting an apt-key

### DIFF
--- a/lib/puppet/provider/apt_key2/apt_key2.rb
+++ b/lib/puppet/provider/apt_key2/apt_key2.rb
@@ -176,7 +176,10 @@ class Puppet::Provider::AptKey2::AptKey2
 
   def delete(context, name, noop = false)
     context.deleting(name) do
-      @apt_key_cmd.run(context, 'del', name, noop: noop)
+      # Although canonicalize logs a warning NOT to use the short id instead of all 40 characters, `apt-key del` fails to delete
+      # on some systems unless the short id is used. Additionally, such systems will return 0 even though deletion failed.
+      # Ref: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1481871
+      @apt_key_cmd.run(context, 'del', name[-8..-1], noop: noop)
     end
   end
 

--- a/spec/unit/puppet/provider/apt_key2/apt_key2_spec.rb
+++ b/spec/unit/puppet/provider/apt_key2/apt_key2_spec.rb
@@ -130,6 +130,7 @@ EOS
     let(:process) { instance_double('ChildProcess::AbstractProcess') }
     let(:io) { instance_double('ChildProcess::AbstractIO') }
     let(:fingerprint) { 'A' * 40 }
+    let(:short) { 'A' * 8 }
 
     before(:each) do
       allow(Puppet::ResourceApi::Command).to receive(:new).and_return(apt_key_cmd)
@@ -216,7 +217,7 @@ EOS
     context 'when deleting a key' do
       it 'updates the system' do
         expect(context).to receive(:deleting).with(fingerprint).and_yield
-        expect(apt_key_cmd).to receive(:run).with(context, 'del', fingerprint, noop: false).and_return 0
+        expect(apt_key_cmd).to receive(:run).with(context, 'del', short, noop: false).and_return 0
         provider.set(context, fingerprint =>
         {
           is: {


### PR DESCRIPTION
See https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1481871 for why the full 40 characters cannot be used on some systems.