### PR TITLE
apt_key2 should account for apt-key warnings being on stdout

### DIFF
--- a/lib/puppet/provider/apt_key2/apt_key2.rb
+++ b/lib/puppet/provider/apt_key2/apt_key2.rb
@@ -159,7 +159,8 @@ class Puppet::Provider::AptKey2::AptKey2
           args.push('--keyserver-options', should[:options])
         end
         args.push('--recv-keys', should[:name])
-        @apt_key_cmd.run(context, *args, noop: noop)
+        # apt-key may write warnings to stdout instead of stderr, therefore make stdout visible
+        @apt_key_cmd.run(context, *args, stdout_loglevel: :notice, noop: noop)
       elsif should[:content]
         temp_key_file(context, name, should[:content]) do |key_file|
           # @apt_key_cmd.run(context, 'add', key_file, noop: noop)

--- a/spec/acceptance/apt_key_provider_spec.rb
+++ b/spec/acceptance/apt_key_provider_spec.rb
@@ -202,7 +202,7 @@ end
           pp = pp_template % { server: server }
 
           result = execute_manifest(pp, trace: false, expect_failures: true)
-          expect(result.stderr).to match(%r{(Host not found|Couldn't resolve host|keyserver receive failed: No name|Invalid value)})
+          expect(result.stderr + result.stdout).to match(%r{(Host not found|Couldn't resolve host|keyserver receive failed: No name|Invalid value)})
         end
       end
 

--- a/spec/unit/puppet/provider/apt_key2/apt_key2_spec.rb
+++ b/spec/unit/puppet/provider/apt_key2/apt_key2_spec.rb
@@ -173,7 +173,7 @@ EOS
     context 'when fetching a key from the keyserver' do
       it 'updates the system' do
         expect(context).to receive(:creating).with(fingerprint).and_yield
-        expect(apt_key_cmd).to receive(:run).with(context, 'adv', '--keyserver', 'keyserver.example.com', '--recv-keys', fingerprint, noop: false).and_return 0
+        expect(apt_key_cmd).to receive(:run).with(context, 'adv', '--keyserver', 'keyserver.example.com', '--recv-keys', fingerprint, stdout_loglevel: :notice, noop: false).and_return 0
         provider.set(context, fingerprint =>
         {
           is: nil,


### PR DESCRIPTION
If apt-key cannot connect to key server, the messages for this appear on stdout and not stderr.
This commit logs stdout at :notice level when adding a key from a server so the warnings are visible in puppet output.